### PR TITLE
bugfix-only-one-left-bar-showing

### DIFF
--- a/es-home/package.json
+++ b/es-home/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@moesol/es-runtime": "workspace:*",
-    "@moesol/es-iframe-to-dev-ext": "workspace:*",
     "@moesol/inter-widget-communication": "^2.8.0-SNAPSHOT.0",
     "@optoolco/tonic": "^13.3.6",
     "events": "^3.3.0",

--- a/es-home/package.json
+++ b/es-home/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@moesol/es-runtime": "workspace:*",
+    "@moesol/es-iframe-to-dev-ext": "workspace:*",
     "@moesol/inter-widget-communication": "^2.8.0-SNAPSHOT.0",
     "@optoolco/tonic": "^13.3.6",
     "events": "^3.3.0",

--- a/es-runtime/src/controllers/BarController.ts
+++ b/es-runtime/src/controllers/BarController.ts
@@ -21,6 +21,13 @@ export class BarController {
         }).then(div => {
             this.divBar = div
             this.updatePanel(panelOptions)
+        }).catch(err => {
+            if (this.divBar) {
+                this.render(this.divBar, panelOptions) // Must be first to set `active`
+                this.updatePanelHeader(panelOptions)
+            } else {
+                console.error('Unexpected failure in addPanel', err)
+            }
         })
     }
 


### PR DESCRIPTION
- async timing could cause issue
- async addPanel not resolved, causing a second call to addPanel, which would reject
- "Error: Already exists es.runtime.left-bar"